### PR TITLE
Fix: Origin Member Id 통해서 Member 조회

### DIFF
--- a/src/main/java/com/uspray/uspray/service/PrayFacade.java
+++ b/src/main/java/com/uspray/uspray/service/PrayFacade.java
@@ -174,9 +174,9 @@ public class PrayFacade {
         pray.countUp();
 
         if (pray.getPrayType() == PrayType.SHARED) {
-            Pray originPray = prayRepository.getPrayById(pray.getOriginPrayId());
-            if (originPray.getMember().getSecondNotiAgree()) {
-                sendNotificationAndSaveLog(pray, originPray.getMember());
+            Member originMember = memberRepository.getMemberById(pray.getOriginMemberId());
+            if (originMember.getSecondNotiAgree()) {
+                sendNotificationAndSaveLog(pray, originMember);
             }
         }
     }


### PR DESCRIPTION
## ✅ PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [ ] 기능 추가
- [ ] 기능 변경
- [ ] 기능 삭제
- [x] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

## 📌 관련 이슈
<!-- 관련있는 이슈 번호(#000)을 적어주세요.
  해당 pull request merge와 함께 이슈를 닫으려면
  closed #Issue_number를 적어주세요 -->
closed #146 

## ✨ 과제 내용
<!-- 과제에 대한 설명을 적어주세요 -->
- PrayType.SHARED 경우 기도하기를 할 때 OriginPrayId를 통해 Origin Member를 찾아 알림을 보내는 구조
- OriginPray가 삭제되었거나 완료된 경우 OriginPray 찾는 중에 NotFoundException 발생
- 따라서 OriginPray를 찾지 않고, Origin Member Id로 바로 Member 조회하게끔 수정

## 📸 스크린샷(선택)
<!-- 스크린샷이 필요한 과제면 스크린샷을 첨부해주세요 -->

## 📚 레퍼런스 (또는 새로 알게 된 내용) 혹은 궁금한 사항들
<!-- 참고할 사항이 있다면 적어주세요 -->
