### PR TITLE
Fix: 보관함에서 저장시 원래 기도제목의 저자의 이름이 저장되도록 수정

### DIFF
--- a/src/main/java/com/uspray/uspray/service/ShareFacade.java
+++ b/src/main/java/com/uspray/uspray/service/ShareFacade.java
@@ -110,11 +110,11 @@ public class ShareFacade {
         List<Long> sharedPrayIds = sharedPraySaveRequestDto.getSharedPrayIds();
 
         for (Long id : sharedPrayIds) {
-            save(member, id, category, sharedPraySaveRequestDto.getDeadline());
+            save(id, category, sharedPraySaveRequestDto.getDeadline());
         }
     }
 
-    private void save(Member member, Long sharedPrayId, Category category, LocalDate deadline) {
+    private void save(Long sharedPrayId, Category category, LocalDate deadline) {
 
         SharedPray sharedPray = sharedPrayRepository.getSharedPrayById(sharedPrayId);
 
@@ -124,11 +124,11 @@ public class ShareFacade {
                 ErrorStatus.PRAY_ALREADY_DELETED_EXCEPTION.getMessage());
         }
         Pray pray = Pray.builder()
-            .member(member)
+            .member(sharedPray.getPray().getMember()) // 원래 기도제목의 원자자가 되어야 함
             .content(new String(Base64.getDecoder().decode(sharedPray.getPray().getContent())))
             .deadline(deadline)
             .originPrayId(sharedPray.getPray().getId())
-            .originMemberId(sharedPray.getMember().getId())
+            .originMemberId(sharedPray.getPray().getMember().getId()) // 원래 기도제목의 원자자가 되어야 함
             .category(category)
             .prayType(PrayType.SHARED)
             .build();


### PR DESCRIPTION
## ✅ PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [ ] 기능 추가
- [ ] 기능 변경
- [ ] 기능 삭제
- [x] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

## 📌 관련 이슈
<!-- 관련있는 이슈 번호(#000)을 적어주세요.
  해당 pull request merge와 함께 이슈를 닫으려면
  closed #Issue_number를 적어주세요 -->
closed #152 

## ✨ 과제 내용
<!-- 과제에 대한 설명을 적어주세요 -->
- 보관함에서 저장할 때 원래 기도제목의 저자의 이름이라 저장하는 사람의 이름 (공유받은 사람)이 저장되던 로직을 수정했습니다.
- A -> B 일때, A 이름이 표시되고, A 에게 알림이 가야하는데, B 이름 표시 및 B 에게 알림이 가는 이슈를 수정했습니다.

## 📸 스크린샷(선택)
<!-- 스크린샷이 필요한 과제면 스크린샷을 첨부해주세요 -->

## 📚 레퍼런스 (또는 새로 알게 된 내용) 혹은 궁금한 사항들
<!-- 참고할 사항이 있다면 적어주세요 -->
