### PR TITLE
fix: groupby와 sorting의 역할을 querydsl로 이전

### DIFF
--- a/src/main/java/com/uspray/uspray/infrastructure/querydsl/group/GroupRepositoryImpl.java
+++ b/src/main/java/com/uspray/uspray/infrastructure/querydsl/group/GroupRepositoryImpl.java
@@ -51,7 +51,9 @@ public class GroupRepositoryImpl implements GroupRepositoryCustom {
                 .max(Comparator.comparing(GroupResponseDto::getUpdatedAt))
                 .orElseThrow(() -> new IllegalArgumentException("그룹이 존재하지 않습니다.")))
             .sorted(
-                Comparator.comparing(GroupResponseDto::getUpdatedAt).reversed()) // 최신 업데이트 날짜로 정렬
+                Comparator.comparing(GroupResponseDto::getUpdatedAt,
+                        Comparator.nullsFirst(Comparator.naturalOrder()))
+                    .reversed()) // 최신 업데이트 날짜로 정렬
             .collect(Collectors.toList());
     }
 

--- a/src/main/java/com/uspray/uspray/infrastructure/querydsl/group/GroupRepositoryImpl.java
+++ b/src/main/java/com/uspray/uspray/infrastructure/querydsl/group/GroupRepositoryImpl.java
@@ -11,7 +11,9 @@ import com.uspray.uspray.DTO.group.response.GroupMemberResponseDto;
 import com.uspray.uspray.DTO.group.response.GroupResponseDto;
 import com.uspray.uspray.DTO.group.response.QGroupMemberResponseDto;
 import com.uspray.uspray.DTO.group.response.QGroupResponseDto;
+import java.util.Comparator;
 import java.util.List;
+import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
 import org.springframework.util.StringUtils;
@@ -25,7 +27,7 @@ public class GroupRepositoryImpl implements GroupRepositoryCustom {
 
     @Override
     public List<GroupResponseDto> findGroupListByMemberId(String userId) {
-        return queryFactory
+        List<GroupResponseDto> result = queryFactory
             .select(new QGroupResponseDto(
                 group.id,
                 group.name,
@@ -42,6 +44,15 @@ public class GroupRepositoryImpl implements GroupRepositoryCustom {
             .groupBy(group.id, group.name, group.leader.userId, groupPray.content)
             .orderBy(groupPray.createdAt.max().desc())
             .fetch();
+        return result.stream()
+            .collect(Collectors.groupingBy(GroupResponseDto::getId))
+            .values().stream()
+            .map(groupResponseDtos -> groupResponseDtos.stream()
+                .max(Comparator.comparing(GroupResponseDto::getUpdatedAt))
+                .orElseThrow(() -> new IllegalArgumentException("그룹이 존재하지 않습니다.")))
+            .sorted(
+                Comparator.comparing(GroupResponseDto::getUpdatedAt).reversed()) // 최신 업데이트 날짜로 정렬
+            .collect(Collectors.toList());
     }
 
     @Override

--- a/src/main/java/com/uspray/uspray/service/GroupService.java
+++ b/src/main/java/com/uspray/uspray/service/GroupService.java
@@ -5,9 +5,7 @@ import com.uspray.uspray.DTO.group.response.GroupMemberResponseDto;
 import com.uspray.uspray.DTO.group.response.GroupResponseDto;
 import com.uspray.uspray.infrastructure.GroupRepository;
 import com.uspray.uspray.util.MaskingUtil;
-import java.util.Comparator;
 import java.util.List;
-import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -21,16 +19,7 @@ public class GroupService {
     @Transactional(readOnly = true)
     public GroupListResponseDto getGroupList(String username) {
         List<GroupResponseDto> groupList = groupRepository.findGroupListByMemberId(username);
-        List<GroupResponseDto> filterMostRecentUpdatedAt =
-            groupList.stream()
-                .collect(Collectors.groupingBy(GroupResponseDto::getId))
-                .values().stream()
-                .map(groupResponseDtos -> groupResponseDtos.stream()
-                    .max(Comparator.comparing(GroupResponseDto::getUpdatedAt))
-                    .orElseThrow(() -> new IllegalArgumentException("그룹이 존재하지 않습니다.")))
-                .collect(Collectors.toList());
-
-        return new GroupListResponseDto(filterMostRecentUpdatedAt);
+        return new GroupListResponseDto(groupList);
     }
 
     @Transactional(readOnly = true)


### PR DESCRIPTION
## ✅ PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [ ] 기능 추가
- [X] 기능 변경
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

## 📌 관련 이슈
<!-- 관련있는 이슈 번호(#000)을 적어주세요.
  해당 pull request merge와 함께 이슈를 닫으려면
  closed #Issue_number를 적어주세요 -->


## ✨ 과제 내용
62. 그룹 목록 불러올 때 가장 최근에 기도제목이 올라간 된 그룹이 위로 올 수 있게끔 순서정렬이 필요할 것 같습니다 (카톡방처럼)

기존 코드는 정렬 후에 group화를 해서 updatedAt 순으로 정렬을 한 것이 반영되지 않았습니다. 
그래서 queryDsl을 수정하여 service단이 아닌 repository 단에서 데이터 조회할 때 그룹화와 정렬을 할 수 있도록 코드를 수정하였습니다. 

## 📸 스크린샷(선택)
<!-- 스크린샷이 필요한 과제면 스크린샷을 첨부해주세요 -->

## 📚 레퍼런스 (또는 새로 알게 된 내용) 혹은 궁금한 사항들
<!-- 참고할 사항이 있다면 적어주세요 -->
