### PR TITLE
[FIX] history 생성시 원본 기도의 시작 날짜를 보관하는 필드 추가 및 불러오는 기능 수정

### DIFF
--- a/src/main/java/com/uspray/uspray/DTO/history/response/HistoryDetailResponseDto.java
+++ b/src/main/java/com/uspray/uspray/DTO/history/response/HistoryDetailResponseDto.java
@@ -23,9 +23,9 @@ public class HistoryDetailResponseDto {
 
     private Integer total_count;
 
-    private LocalDate deadline;
+    private LocalDate startDate;
 
-    private LocalDate createdAt;
+    private LocalDate deadline;
 
     private Long categoryId;
 
@@ -34,16 +34,16 @@ public class HistoryDetailResponseDto {
     public static HistoryDetailResponseDto of(History history) {
         return new HistoryDetailResponseDto(history.getId(), history.getMember().getName(),
             history.getContent(), history.getPersonalCount(), history.getTotalCount(),
-            history.getDeadline(),
-            history.getCreatedAt().toLocalDate(), history.getCategoryId(),
+            history.getStartDate(), history.getDeadline(),
+            history.getCategoryId(),
             history.getPrayType() == PrayType.PERSONAL && !history.getIsShared());
     }
 
     public static HistoryDetailResponseDto shared(History history, Pray originPray) {
         return new HistoryDetailResponseDto(history.getId(), originPray.getMember().getName(),
             history.getContent(), history.getPersonalCount(), history.getTotalCount(),
-            history.getDeadline(),
-            history.getCreatedAt().toLocalDate(), history.getCategoryId(),
+            history.getStartDate(), history.getDeadline(),
+            history.getCategoryId(),
             history.getPrayType() == PrayType.PERSONAL && !history.getIsShared());
     }
 }

--- a/src/main/java/com/uspray/uspray/DTO/history/response/HistoryResponseDto.java
+++ b/src/main/java/com/uspray/uspray/DTO/history/response/HistoryResponseDto.java
@@ -5,7 +5,6 @@ import com.uspray.uspray.domain.History;
 import com.uspray.uspray.domain.Member;
 import io.swagger.v3.oas.annotations.media.Schema;
 import java.time.LocalDate;
-import java.time.LocalDateTime;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -24,9 +23,9 @@ public class HistoryResponseDto {
 
     private String content;
 
-    private LocalDate deadline;
+    private LocalDate createdAt;
 
-    private LocalDateTime createdAt;
+    private LocalDate deadline;
 
     private Long categoryId;
 
@@ -34,15 +33,14 @@ public class HistoryResponseDto {
 
     public static HistoryResponseDto of(History history) {
         return new HistoryResponseDto(history.getId(), history.getMember().getUserId(),
-            history.getMember().getName(), history.getContent(), history.getDeadline(),
-            history.getCreatedAt(), history.getCategoryId(),
+            history.getMember().getName(), history.getContent(), history.getStartDate(), history.getDeadline(), history.getCategoryId(),
             history.getPrayType() == PrayType.PERSONAL && !history.getIsShared());
     }
 
     public static HistoryResponseDto shared(History history, Member originMember) {
         return new HistoryResponseDto(history.getId(), originMember.getUserId(),
-            originMember.getName(), history.getContent(), history.getDeadline(),
-            history.getCreatedAt(), history.getCategoryId(), false); // 공유받은 기도제목은 수정 불가능, 항상 false
+            originMember.getName(), history.getContent(), history.getStartDate(), history.getDeadline(),
+            history.getCategoryId(), false); // 공유받은 기도제목은 수정 불가능, 항상 false
     }
 
 }

--- a/src/main/java/com/uspray/uspray/DTO/pray/request/PrayRequestDto.java
+++ b/src/main/java/com/uspray/uspray/DTO/pray/request/PrayRequestDto.java
@@ -31,13 +31,25 @@ public class PrayRequestDto {
   @Schema(description = "기도제목 카테고리", example = "1")
   private Long categoryId;
 
-  public Pray toEntity(Member member, Category category, PrayType prayType) {
+  public Pray toEntity(Member member, Category category) {
     return Pray.builder()
         .content(content)
         .deadline(deadline)
         .member(member)
         .category(category)
-        .prayType(prayType)
+        .prayType(PrayType.PERSONAL)
+        .startDate(LocalDate.now())
+        .build();
+  }
+
+  public Pray toEntity(Member member, Category category, LocalDate startDate) {
+    return Pray.builder()
+        .content(content)
+        .deadline(deadline)
+        .member(member)
+        .category(category)
+        .prayType(PrayType.PERSONAL)
+        .startDate(startDate)
         .build();
   }
 }

--- a/src/main/java/com/uspray/uspray/InitDb.java
+++ b/src/main/java/com/uspray/uspray/InitDb.java
@@ -166,6 +166,7 @@ public class InitDb {
                 .member(member)
                 .category(category)
                 .prayType(PrayType.PERSONAL)
+                .startDate(LocalDate.of(2022, 12, 24))
                 .build();
             em.persist(pray);
 
@@ -175,6 +176,7 @@ public class InitDb {
                 .member(member2)
                 .category(category2_by_member2)
                 .prayType(PrayType.PERSONAL)
+                .startDate(LocalDate.of(2023, 12, 24))
                 .build();
             em.persist(pray_1);
 
@@ -184,6 +186,7 @@ public class InitDb {
                 .member(member)
                 .category(category3_by_member)
                 .prayType(PrayType.SHARED)
+                .startDate(LocalDate.of(2023, 12, 24))
                 .originPrayId(pray_1.getId())
                 .build();
             em.persist(pray1);
@@ -194,6 +197,7 @@ public class InitDb {
                 .member(member2)
                 .category(category4_by_member2)
                 .prayType(PrayType.SHARED)
+                .startDate(LocalDate.of(2023, 12, 24))
                 .originPrayId(pray.getId())
                 .build();
             em.persist(pray2);
@@ -204,6 +208,7 @@ public class InitDb {
                 .member(member)
                 .category(category1_by_member)
                 .prayType(PrayType.PERSONAL)
+                .startDate(LocalDate.of(2023, 12, 24))
                 .build();
             em.persist(pray3);
 

--- a/src/main/java/com/uspray/uspray/domain/History.java
+++ b/src/main/java/com/uspray/uspray/domain/History.java
@@ -62,7 +62,7 @@ public class History extends AuditingTimeEntity {
         this.content = pray.getContent();
         this.personalCount = pray.getCount();
         this.totalCount = (totalCount == null) ? 0 : totalCount; // totalCount에 기본값 설정
-        this.startDate = LocalDate.from(pray.getCreatedAt());
+        this.startDate = LocalDate.from(pray.getStartDate());
         this.deadline = pray.getDeadline();
         this.originPrayId = pray.getOriginPrayId();
         this.originMemberId = pray.getOriginMemberId();

--- a/src/main/java/com/uspray/uspray/domain/History.java
+++ b/src/main/java/com/uspray/uspray/domain/History.java
@@ -39,6 +39,7 @@ public class History extends AuditingTimeEntity {
 
     private Integer totalCount;
 
+    private LocalDate startDate;
     private LocalDate deadline;
 
     @Column(name = "origin_pray_id")
@@ -61,6 +62,7 @@ public class History extends AuditingTimeEntity {
         this.content = pray.getContent();
         this.personalCount = pray.getCount();
         this.totalCount = (totalCount == null) ? 0 : totalCount; // totalCount에 기본값 설정
+        this.startDate = LocalDate.from(pray.getCreatedAt());
         this.deadline = pray.getDeadline();
         this.originPrayId = pray.getOriginPrayId();
         this.originMemberId = pray.getOriginMemberId();

--- a/src/main/java/com/uspray/uspray/domain/Pray.java
+++ b/src/main/java/com/uspray/uspray/domain/Pray.java
@@ -62,12 +62,14 @@ public class Pray extends AuditingTimeEntity {
     @JoinColumn(name = "category_id")
     private Category category;
 
+    @NotNull
+    private LocalDate startDate;
+
     private LocalDate lastPrayedAt;
 
     @Builder
     public Pray(Member member, String content, LocalDate deadline, Long originPrayId,
-        Long originMemberId,
-        Category category, PrayType prayType, GroupPray groupPray) {
+        Long originMemberId, Category category, PrayType prayType, GroupPray groupPray, LocalDate startDate) {
         this.member = member;
         this.content = new String(Base64.getEncoder().encode(content.getBytes()));
         this.count = 0;
@@ -77,6 +79,7 @@ public class Pray extends AuditingTimeEntity {
         this.category = category;
         this.prayType = prayType;
         setGroupPray(groupPray);
+        this.startDate = startDate;
         this.lastPrayedAt = LocalDate.of(2002, 2, 24);
     }
 

--- a/src/main/java/com/uspray/uspray/infrastructure/CategoryRepository.java
+++ b/src/main/java/com/uspray/uspray/infrastructure/CategoryRepository.java
@@ -4,6 +4,7 @@ import com.uspray.uspray.Enums.CategoryType;
 import com.uspray.uspray.domain.Category;
 import com.uspray.uspray.domain.Member;
 import com.uspray.uspray.exception.ErrorStatus;
+import com.uspray.uspray.exception.model.CustomException;
 import com.uspray.uspray.exception.model.NotFoundException;
 import com.uspray.uspray.infrastructure.querydsl.category.CategoryRepositoryCustom;
 import java.util.List;
@@ -22,12 +23,19 @@ public interface CategoryRepository extends JpaRepository<Category, Long>,
         CategoryType categoryType);
 
     default Category getCategoryByIdAndMember(Long categoryId, Member member) {
-        return findById(categoryId)
-            .filter(category -> category.getMember().equals(member))
+        Category category = findById(categoryId)
+            .filter(c ->  c.getMember().equals(member))
             .orElseThrow(() -> new NotFoundException(
                 ErrorStatus.CATEGORY_NOT_FOUND_EXCEPTION,
                 ErrorStatus.CATEGORY_NOT_FOUND_EXCEPTION.getMessage()
             ));
+
+        if (!category.getCategoryType().equals(CategoryType.PERSONAL)) {
+            throw new CustomException(ErrorStatus.PRAY_CATEGORY_TYPE_MISMATCH,
+                ErrorStatus.PRAY_CATEGORY_TYPE_MISMATCH.getMessage());
+        }
+
+        return category;
     }
 
     default void checkDuplicate(String name, Member member, CategoryType type) {

--- a/src/main/java/com/uspray/uspray/infrastructure/HistoryRepository.java
+++ b/src/main/java/com/uspray/uspray/infrastructure/HistoryRepository.java
@@ -5,6 +5,7 @@ import com.uspray.uspray.domain.Member;
 import com.uspray.uspray.exception.ErrorStatus;
 import com.uspray.uspray.exception.model.NotFoundException;
 import com.uspray.uspray.infrastructure.querydsl.history.HistoryRepositoryCustom;
+import java.util.Optional;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -18,7 +19,13 @@ public interface HistoryRepository extends JpaRepository<History, Long>, History
     Page<History> findByMemberAndOriginPrayIdIsNotNull(Member member, Pageable pageable);
 
 
-    History findByIdAndMember(Long historyId, Member member);
+    Optional<History> findByIdAndMember(Long historyId, Member member);
+
+    default History getHistoryByIdAndMember(Long historyId, Member member) {
+        return findByIdAndMember(historyId, member)
+            .orElseThrow(() -> new NotFoundException(ErrorStatus.HISTORY_NOT_FOUND_EXCEPTION,
+                ErrorStatus.HISTORY_NOT_FOUND_EXCEPTION.getMessage()));
+    }
 
     default History getHistoryById(Long historyId) {
         return findById(historyId)

--- a/src/main/java/com/uspray/uspray/infrastructure/querydsl/history/HistoryRepositoryImpl.java
+++ b/src/main/java/com/uspray/uspray/infrastructure/querydsl/history/HistoryRepositoryImpl.java
@@ -57,7 +57,7 @@ public class HistoryRepositoryImpl implements HistoryRepositoryCustom {
     }
 
     private BooleanExpression dateEq(LocalDate startDate, LocalDate endDate) {
-        return startDate != null && endDate != null ? history.createdAt.before(
-            endDate.atStartOfDay()).and(history.deadline.after(startDate)) : null;
+        return startDate != null && endDate != null ? history.startDate.before(
+            endDate).and(history.deadline.after(startDate)) : null;
     }
 }

--- a/src/main/java/com/uspray/uspray/service/HistoryFacade.java
+++ b/src/main/java/com/uspray/uspray/service/HistoryFacade.java
@@ -1,0 +1,33 @@
+package com.uspray.uspray.service;
+
+import com.uspray.uspray.DTO.pray.request.PrayRequestDto;
+import com.uspray.uspray.DTO.pray.response.PrayResponseDto;
+import com.uspray.uspray.domain.History;
+import com.uspray.uspray.domain.Member;
+import com.uspray.uspray.infrastructure.HistoryRepository;
+import com.uspray.uspray.infrastructure.MemberRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class HistoryFacade {
+
+    private final PrayFacade prayFacade;
+    private final MemberRepository memberRepository;
+    private final HistoryRepository historyRepository;
+
+    @Transactional
+    public PrayResponseDto historyToPray(PrayRequestDto prayRequestDto, String username, Long historyId) {
+        Member member = memberRepository.getMemberByUserId(username);
+        History history = historyRepository.getHistoryByIdAndMember(historyId, member);
+
+        historyRepository.delete(history);
+
+        return prayFacade.createPray(prayRequestDto, username,
+            history.getStartDate());
+    }
+
+
+}

--- a/src/main/java/com/uspray/uspray/service/HistoryService.java
+++ b/src/main/java/com/uspray/uspray/service/HistoryService.java
@@ -83,14 +83,4 @@ public class HistoryService {
         }
         return HistoryDetailResponseDto.of(history);
     }
-
-    public void deleteHistory(Long historyId, String username) {
-        Member member = memberRepository.getMemberByUserId(username);
-        History history = historyRepository.findByIdAndMember(historyId, member);
-        if (history == null) {
-            throw new NotFoundException(ErrorStatus.HISTORY_NOT_FOUND_EXCEPTION,
-                ErrorStatus.HISTORY_NOT_FOUND_EXCEPTION.getMessage());
-        }
-        historyRepository.delete(history);
-    }
 }

--- a/src/main/java/com/uspray/uspray/service/PrayFacade.java
+++ b/src/main/java/com/uspray/uspray/service/PrayFacade.java
@@ -4,7 +4,6 @@ import com.uspray.uspray.DTO.pray.PrayListResponseDto;
 import com.uspray.uspray.DTO.pray.request.PrayRequestDto;
 import com.uspray.uspray.DTO.pray.request.PrayUpdateRequestDto;
 import com.uspray.uspray.DTO.pray.response.PrayResponseDto;
-import com.uspray.uspray.Enums.CategoryType;
 import com.uspray.uspray.Enums.PrayType;
 import com.uspray.uspray.domain.Category;
 import com.uspray.uspray.domain.History;
@@ -47,11 +46,19 @@ public class PrayFacade {
         Category category = categoryRepository.getCategoryByIdAndMember(
             prayRequestDto.getCategoryId(),
             member);
-        if (!category.getCategoryType().equals(CategoryType.PERSONAL)) {
-            throw new CustomException(ErrorStatus.PRAY_CATEGORY_TYPE_MISMATCH,
-                ErrorStatus.PRAY_CATEGORY_TYPE_MISMATCH.getMessage());
-        }
-        Pray pray = prayRequestDto.toEntity(member, category, PrayType.PERSONAL);
+
+        Pray pray = prayRequestDto.toEntity(member, category);
+        prayRepository.save(pray);
+        return PrayResponseDto.of(pray);
+    }
+
+    @Transactional
+    public PrayResponseDto createPray(PrayRequestDto prayRequestDto, String username, LocalDate startDate) {
+        Member member = memberRepository.getMemberByUserId(username);
+        Category category = categoryRepository.getCategoryByIdAndMember(
+            prayRequestDto.getCategoryId(),
+            member);
+        Pray pray = prayRequestDto.toEntity(member, category, startDate);
         prayRepository.save(pray);
         return PrayResponseDto.of(pray);
     }


### PR DESCRIPTION
## ✅ PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [ ] 기능 추가
- [x] 기능 변경
- [ ] 기능 삭제
- [x] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

## 📌 관련 이슈
<!-- 관련있는 이슈 번호(#000)을 적어주세요.
  해당 pull request merge와 함께 이슈를 닫으려면
  closed #Issue_number를 적어주세요 -->
ex) closed #Issue_number
closed #161 

## ✨ 과제 내용
<!-- 과제에 대한 설명을 적어주세요 -->
* History 도메인에 기도 시작날짜를 저장하는 startDate 필드를 추가하였습니다.
* History 생성시 pray의 생성 날짜를 startDate에 주입하도록 변경하였습니다.
* History 검색시 날짜 범위 설정을 startDate를 참고하도록 변경하였습니다.
* History에서 Pray를 생성할 때 startDate가 보존되기 위해서 관련 컬럼을 추가 & 관련 로직들을 수정하였습니다.

## 📸 스크린샷(선택)
<!-- 스크린샷이 필요한 과제면 스크린샷을 첨부해주세요 -->

## 📚 레퍼런스 (또는 새로 알게 된 내용) 혹은 궁금한 사항들
<!-- 참고할 사항이 있다면 적어주세요 -->
