### PR TITLE
fix: 카테고리 이름 중복으로 인한 에러 처리 해결

### DIFF
--- a/src/main/java/com/uspray/uspray/service/CategoryService.java
+++ b/src/main/java/com/uspray/uspray/service/CategoryService.java
@@ -89,7 +89,7 @@ public class CategoryService {
         CategoryRequestDto categoryRequestDto) {
         Category category = categoryRepository.getCategoryByIdAndMember(categoryId,
             memberRepository.getMemberByUserId(username));
-        if (categoryRequestDto.getName() != null) {
+        if (categoryRequestDto.getName() != null && !categoryRequestDto.getName().equals(category.getName())) {
             categoryRepository.checkDuplicate(categoryRequestDto.getName(), category.getMember(),
                 CategoryType.valueOf(categoryRequestDto.getType().toUpperCase()));
         }


### PR DESCRIPTION
## ✅ PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [ ] 기능 추가
- [ ] 기능 변경
- [ ] 기능 삭제
- [x] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

## 📌 관련 이슈
<!-- 관련있는 이슈 번호(#000)을 적어주세요.
  해당 pull request merge와 함께 이슈를 닫으려면
  closed #Issue_number를 적어주세요 -->
closed #178

## ✨ 과제 내용
<!-- 과제에 대한 설명을 적어주세요 -->
카테고리를 이름 수정 없이 색상이나 타입만 수정했을 때,
중복된 카테고리라고 인식하게 되어 발생하는 에러였습니다.
해결을 위해 request로 받은 카테고리 이름이 null이 아니고 조회해온 카테고리와 이름이 "같지 않을 때"에만 이름 중복 여부를 확인하도록 수정하였습니다.

## 📸 스크린샷(선택)
<!-- 스크린샷이 필요한 과제면 스크린샷을 첨부해주세요 -->

## 📚 레퍼런스 (또는 새로 알게 된 내용) 혹은 궁금한 사항들
<!-- 참고할 사항이 있다면 적어주세요 -->
